### PR TITLE
adding accumulo roles

### DIFF
--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -760,7 +760,7 @@
           "info_log_size" : "{{  accumulo_info_log_size| default('512M') }}",
           "audit_log_level" : "{{ accumulo_audit_log_level | default('OFF') }}",
           "debug_log_size" : "{{ accumulo_debug_log_size | default('512M') }}",
-          "info_num_logs" : "{{ accumulo_info_num_logs | default('10') }}"
+          "info_num_logs" : "{{ accumulo_info_num_logs | default('10') }}",
          }
       }
     },


### PR DESCRIPTION
Adding accumulo logging, leaving memory options up to ambari for default and user can set in API if necessary.