### PR TITLE
Ambari repo modification

### DIFF
--- a/playbooks/roles/ambari-repo/tasks/main.yml
+++ b/playbooks/roles/ambari-repo/tasks/main.yml
@@ -31,6 +31,7 @@
     state: present
     gpgcheck: "{{ ambari_yum_repo_gpgcheck }}"
     gpgkey: "{{ ambari_yum_repo_gpgkey }}"
+    proxy: "_none_"
   when: ansible_os_family|lower == "redhat"
 
 - name: Add the Ambari repository (zypper)


### PR DESCRIPTION
Ambari yum repository gets layed down on a node in the private cluster (basebox for us). This change allows full installation to succeed in environments like a private subnet in AWS where the global yum configuration may be routed through a proxy (proxy line in /etc/yum.conf).

This change trades one assumption for another:
- currently we assume environment is setup with no proxy yum configuration (a common pattern in AWS, expecially in CSE).
- new assumption is that the ambari repo is layed down on a machine on the local network

I argue that the second assumption is more reasonable.