### PR TITLE
DNS variable cleanup. This is an effort to remove all extraneous DNS …

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -34,17 +34,6 @@
     enabled: yes
   ignore_errors: true
 
-- name: Add mappings to /etc/hosts
-  lineinfile:
-    path: /etc/hosts
-    regexp: "^{{ hostvars[item]['ansible_'~hostvars[item].ansible_default_ipv4.alias]['ipv4']['address'] }}.*"
-    line: "{{ hostvars[item]['ansible_'~hostvars[item].ansible_default_ipv4.alias]['ipv4']['address'] }} {{ hostvars[item]['ansible_nodename'] }}"
-    insertafter: "^127..*$"
-    state: present
-  with_items:
-    - "{{ groups['hadoop-cluster']|sort(reverse=True) }}"
-  when: not external_dns
-
 - name: Make sure /etc/security/limits.d exists
   file:
     path: /etc/security/limits.d


### PR DESCRIPTION
DNS variable cleanup. This is an effort to remove all extraneous DNS variables from the ACS baseline. There has been confusion about: 
- external_dns 
- acs_external_dns (defined in tcri.yml and in the named role)
- named variables in tcri.yml that are not used. 

We don't support basebox DNS, so rather than bake it into our installation, it is now a tool that can be configured before acs-install as such: 

ansible-playbook -vvkKbu sysadmin configure_basebox_dns 

This requires installers in a non-production environment to explicitly install basebox dns without tracing through the code to answer questions such as: "Does 'not acs_external_dns' mean not using a DNS that is external to ACS or does it mean not using an internal ACS DNS, or perhaps that just means using an external DNS?" Since these variables are gone in favor of requiring an explicit call to setup external DNS, only 1 variable is needed which is dns_upstream_servers. Any problems with this setup should be addressed by fixing DNS, and not falling back on /etc/hosts mappings.