### PR TITLE
Adding entry for client.jartransformer.class

### DIFF
--- a/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
+++ b/playbooks/roles/ambari-blueprint/templates/blueprint_dynamic.j2
@@ -922,7 +922,7 @@
 {% if storm_supervisor_opts is defined %}
         "supervisor.slots.ports" : "[{% for x in range(0,storm_worker_slots) %}{{ 6700|int + x }}{% if not loop.last %},{% endif %}{% endfor %}]",
 {% endif %}
-
+        "client.jartransformer.class" : "nil"
       }
     },
     {


### PR DESCRIPTION
To support multi-release JARs. Following is the original ticket details from ACS3-7319:

The Hortonworks installation of storm is configured by default to perform transformation of class files in legacy jars during topology submission. The transformation step is controlled by a property in storm.yaml with the key client.jartransformer.class and the default value for Hortonworks is org.apache.storm.hack.StormShadeTransformer

This transformation step uses the ASM library to package-relocate classes built against legacy version of storm (predating 1.0). The version of ASM that is used to do this only supports class files built against Java 8 and earlier. If a topology jar contains a class with a version of Java 9 or newer, the transformation step will fail with the following output.

```
Exception in thread "main" java.lang.IllegalArgumentException
        at org.apache.storm.hack.shade.org.objectweb.asm.ClassReader.<init>(Unknown Source)
        at org.apache.storm.hack.shade.org.objectweb.asm.ClassReader.<init>(Unknown Source)
        at org.apache.storm.hack.shade.org.objectweb.asm.ClassReader.<init>(Unknown Source)
        at org.apache.storm.hack.DefaultShader.addRemappedClass(DefaultShader.java:182)
        at org.apache.storm.hack.DefaultShader.shadeJarStream(DefaultShader.java:103)
        at org.apache.storm.hack.StormShadeTransformer.transform(StormShadeTransformer.java:35)
        at org.apache.storm.daemon.ClientJarTransformerRunner.main(ClientJarTransformerRunner.java:37)
```

Java 9 introduced a new feature called Multi-Release JAR Files under JEP 238 http://openjdk.java.net/jeps/238 and recent versions of libraries such as ElasticSearch have started to build multi-release jars that contain classes with versions newer than Java 9. Due to the aformentioned lack of support for Java 9 and newer, the transformation step fails and prevents the submission of topologies.

Storm can be configured to skip the transformation step by either removing the client.jartransformer.class from storm.yaml or setting its value to 'nil'. The former does not appear to be possible with Hortonworks distributions since a non-empty value is required.

https://gitlab.ow2.org/asm/asm/blob/ASM_5_0_2/src/org/objectweb/asm/ClassReader.java#L169-171

https://github.com/hortonworks/storm-release/blob/HDP-2.6.5.3008-9-tag/bin/storm.py#L308

I am recommending setting the value to 'nil' in future ACS releases to support topologies that have dependencies on multi-release jars.